### PR TITLE
tagline update

### DIFF
--- a/modules/StartCall/StartCall.tsx
+++ b/modules/StartCall/StartCall.tsx
@@ -23,7 +23,7 @@ export const StartCall:FC = () => {
           stroke={"currentColor"}
         />
       </span> */}
-      <span>Start Call</span>
+      <span>Call Eliza</span>
     </Button>
   )
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Home: FC = ({
                   Ikigai Labs
                 </h1>
                 <div className="flex justify-end translate-x-4 -mt-6">
-                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Living The ELIZA Life</h2>
+                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Ask Her Anything</h2>
                 </div>
               </div>
               <div className="mt-4 md:mt-0 md:pl-16 flex justify-center items-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Home: FC = ({
                   Ikigai Labs
                 </h1>
                 <div className="flex justify-end translate-x-4 -mt-6">
-                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Powered by ai16z Agent Eliza framework</h2>
+                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Hypermedia & Autonomous Agents</h2>
                 </div>
               </div>
               <div className="mt-4 md:mt-0 md:pl-16 flex justify-center items-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Home: FC = ({
                   Ikigai Labs
                 </h1>
                 <div className="flex justify-end translate-x-4 -mt-6">
-                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Eliza Awaits Your Call</h2>
+                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Living The ELIZA Life</h2>
                 </div>
               </div>
               <div className="mt-4 md:mt-0 md:pl-16 flex justify-center items-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Home: FC = ({
                   Ikigai Labs
                 </h1>
                 <div className="flex justify-end translate-x-4 -mt-6">
-                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Ask Her Anything</h2>
+                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Powered by ai16z Agent Eliza framework</h2>
                 </div>
               </div>
               <div className="mt-4 md:mt-0 md:pl-16 flex justify-center items-center">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -107,7 +107,7 @@ const Home: FC = ({
                   Ikigai Labs
                 </h1>
                 <div className="flex justify-end translate-x-4 -mt-6">
-                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Curated Art Explorer</h2>
+                  <h2 className="text-2xl bg-black text-yellow inline-block leading-none p-2">Eliza Awaits Your Call</h2>
                 </div>
               </div>
               <div className="mt-4 md:mt-0 md:pl-16 flex justify-center items-center">


### PR DESCRIPTION
replace "curated art explorer" with a new tagline that indicates/references the main CTA on the homepage